### PR TITLE
ZEN-231: Code Coverage Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ temp
 
 # code coverage
 coverage/
+reports/
 
 # OSX
 #

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf yarn.lock; rimraf package.lock; rimraf node_modules ",
-    "test": "NODE_ENV=resolver-test jest"
+    "test": "NODE_ENV=resolver-test jest",
+    "test:reports": "yarn test --coverage && yarn view:reports",
+    "view:reports": "open reports/coverage/lcov-report/index.html"
   },
   "dependencies": {
     "@babel/cli": "^7.5.5",
@@ -44,8 +46,10 @@
       "<rootDir>/src/**/__tests__/**/*.js?(x)"
     ],
     "collectCoverageFrom": [
-      "<rootDir>/src/index.js"
+      "src/**/*.{js,jsx}",
+      "!**/mocks/**/*.{js,jsx}"
     ],
+    "coverageDirectory": "reports/coverage",
     "moduleFileExtensions": [
       "js",
       "json",


### PR DESCRIPTION
**Ticket**: [ZEN-231](https://jira.simpleviewtools.com/browse/ZEN-231)

## Context

* For ZEN-231, I was reviewing the repositories and what code needed testing in each
* Code coverage wasn't working for tap-resolver

## Goal

* To get code coverage working

## Updates

### `package.json`
* added commands for testing with coverage and viewing the reports in a browser
* fixed code coverage by updating the glob pattern
* also moved output into reports/coverage to be consistent

### `.gitignore`
* gitignored the new `reports/` directory

## Testing

* run `yarn test:reports`
* verify that the terminal shows code coverage and test results
* verify that a browser tab appears showing the coverage results

