### PR TITLE
Gh action publish to gh packages:

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,23 @@
+name: Publish
+
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+
+jobs:
+
+  build_and_deploy_package:
+    runs-on: ubuntu-latest
+    steps:
+      
+    # Checks-out the repo on branch master (default) under $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+
+    - name: Setup and publish
+      env:
+        GIT_KEY: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        yarn publish
+


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-241)

## Context

* now that we have Github packages setup on these repos, add github actions to do the build and deploy to `github packages` whenever something is pushed to `master`

## Goal

* Create a github action for push to `master`
     * sets up the environment
     * publish to `github packages`

## Updates

* `.github/workflows/publish-package.yml`
   * sets up github actions to build and publish whenever a new commit is added to `master`

## Testing

### Setup
* Pull `master-test` branch from [my fork](https://github.com/daniel112/tap-resolver/tree/master-test)
    * It's identical to this PR branch with minor change in `package.json` so it would upload a package to my fork instead

* Update `package.json`
     * Verify that the `name` key is `@daniel112/re-theme`
     * Verify that the `repository` key has `"ssh://git@github.com/daniel112/re-theme.git"`
     * Change the `version` to be anything greater than what it currently is


### action
* commit and push the `package.json` change
* Head to the actions tab on my fork repo: https://github.com/daniel112/tap-resolver/actions
* Verify that the Action succeeds
* Verify that it successfully uploads the package with the new version to your repo's gh packages
     * https://github.com/daniel112/tap-resolver/packages/238375

* Verify that you see your version is listed under `recent versions` or it has become the `latest version`
    *  ![image](https://user-images.githubusercontent.com/3317835/83435820-b78ae380-a3f1-11ea-9baf-0c9205d97300.png)


